### PR TITLE
Append to CFLAGS and CXXFLAGS to use values passed to ./configure

### DIFF
--- a/Makefile-shared.mk
+++ b/Makefile-shared.mk
@@ -12,10 +12,10 @@ OBJS= \
 	${objsdir}/sqlite3.o
 
 # C Compiler Flags
-CFLAGS= -fPIC -MMD -MP
+CFLAGS+= -fPIC -MMD -MP
 
 # CC Compiler Flags
-CPPFLAGS= -DKOMPEX_SQLITEWRAPPER_EXPORT -DKOMPEX_SQLITEWRAPPER_DYN -fPIC -MMD -MP -I${includedir}
+CPPFLAGS+= -DKOMPEX_SQLITEWRAPPER_EXPORT -DKOMPEX_SQLITEWRAPPER_DYN -fPIC -MMD -MP -I${includedir}
 
 # Link Libraries and Options
 LDLIBSOPTIONS= -shared -fPIC

--- a/Makefile-static.mk
+++ b/Makefile-static.mk
@@ -12,10 +12,10 @@ OBJS= \
 	${objsdir}/sqlite3.o
 
 # C Compiler Flags
-CFLAGS= -MMD -MP
+CFLAGS+= -MMD -MP
 
 # CC Compiler Flags
-CPPFLAGS= -I${includedir} -MMD -MP
+CPPFLAGS+= -I${includedir} -MMD -MP
 
 # Link Libraries and Options
 LDLIBSOPTIONS=


### PR DESCRIPTION
Append to CFLAGS and CXXFLAGS to use values passed to ./configure. This can allow users to customize the SQLite build process with compile time #defines rather than altering the sources directly.  EG, with this,

``` shell
CFLAGS="-DSQLITE_MAX_COLUMN=4000" ./configure && make
```

Allows for compile time determination of the maximum number of columns allowed in a SQLite table.
